### PR TITLE
Use real @actions user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 # initialize git
 remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 git config user.name "Automated Publisher"
-git config user.email "publish-to-github-action@users.noreply.github.com"
+git config user.email "actions@users.noreply.github.com"
 git remote add publisher "${remote_repo}"
 git show-ref # useful for debugging
 git branch --verbose


### PR DESCRIPTION
https://github.com/publish-to-github-action isn't a real user but https://github.com/actions is (an org) so the email is valid